### PR TITLE
ペット一覧の更新とその他細かい修正

### DIFF
--- a/routes/pet.py
+++ b/routes/pet.py
@@ -138,3 +138,16 @@ def get_state(pet_id):
         'level': pet.level,
         'exp': pet.exp
     })
+
+# 全てのペットの幸福度の状態を返すAPI
+@pet_bp.route("/states", methods=["GET"])
+def get_all_states():
+    pets = Pet.select()
+
+    pets_data = [{
+        "id": pet.id,
+        "happiness": pet.happiness, 
+        "level": pet.level
+    } for pet in pets]
+
+    return jsonify(pets_data)

--- a/routes/pet.py
+++ b/routes/pet.py
@@ -90,6 +90,8 @@ def care(pet_id):
             happiness_increase = 30
         elif action == 'reset':
             pet.happiness = 0
+        elif action == 'reset-level':
+            pet.level = 1
             pet.save()
             return redirect(url_for('pet.care', pet_id=pet_id))
 

--- a/static/base-style.css
+++ b/static/base-style.css
@@ -158,3 +158,7 @@ ul {
   object-fit: cover;
   border-radius: 5px;
 }
+
+.pet-list-image img:hover {
+  transform: scale(1.02);
+}

--- a/static/base-style.css
+++ b/static/base-style.css
@@ -152,3 +152,9 @@ ul {
   text-align: center;
   margin-right: 390px;
 }
+
+.pet-list-image img {
+  height: 150px;
+  object-fit: cover;
+  border-radius: 5px;
+}

--- a/templates/pet_add.html
+++ b/templates/pet_add.html
@@ -9,7 +9,6 @@
     <h1>新しいペットの作成</h1>
     <ul class="breadcrumb">
         <li><a href="{{ url_for('pet.index') }}">HOME</a></li>
-        <li><a href="{{ url_for('pet.list') }}">ペット一覧</a></li>
     </ul>
 
     <div class="label-center">種類を選んでね</div>

--- a/templates/pet_care.html
+++ b/templates/pet_care.html
@@ -60,6 +60,9 @@
         <button type="submit" name="action" value="reset">
           幸福度リセット（後で消す）
         </button>
+        <button type="submit" name="action" value="reset-level">
+          レベルリセット（後で消す）
+        </button>
       </footer>
     </form>
     <script>

--- a/templates/pet_care.html
+++ b/templates/pet_care.html
@@ -73,7 +73,7 @@
       }
 
       // 定期的に状態を更新
-      setInterval(fetchState, 10000); // 状態を1秒ごとに取得
+      setInterval(fetchState, 1000); // 状態を1秒ごとに取得
     </script>
   </body>
 </html>

--- a/templates/pet_list.html
+++ b/templates/pet_list.html
@@ -40,7 +40,10 @@
                         <label>
                             {% set pet_types = ['dog', 'cat', 'bird'] %}
                             {% set growth_stage = 'adult' if pet.level >= 6 else 'young' if pet.level >= 3 else 'baby' %}
-                            <img src="{{ url_for('static', filename='images/' + pet_types[pet.type] + '_' + growth_stage + '_neutral.jpg') }}" alt="ペットの画像">
+                            <a href="{{ url_for('pet.care', pet_id=pet.id) }}">
+                                <img src="{{ url_for('static', filename='images/' + pet_types[pet.type] + '_' + growth_stage + '_neutral.jpg') }}" 
+                                     alt="ペットの画像">
+                            </a>
                         </label>
                     </div>
                 </td>

--- a/templates/pet_list.html
+++ b/templates/pet_list.html
@@ -38,13 +38,9 @@
                 <td>
                     <div class="pet-option">
                         <label>
-                            {% if pet.type == 0 %}
-                                <img src="{{ url_for('static', filename='images/dog.jpeg') }}" alt="犬の画像">
-                            {% elif pet.type == 1 %}
-                                <img src="{{ url_for('static', filename='images/cat.jpg') }}" alt="猫の画像">
-                            {% elif pet.type == 2 %}
-                                <img src="{{ url_for('static', filename='images/bird.jpg') }}" alt="鳥の画像">
-                            {% endif %}
+                            {% set pet_types = ['dog', 'cat', 'bird'] %}
+                            {% set growth_stage = 'adult' if pet.level >= 6 else 'young' if pet.level >= 3 else 'baby' %}
+                            <img src="{{ url_for('static', filename='images/' + pet_types[pet.type] + '_' + growth_stage + '_neutral.jpg') }}" alt="ペットの画像">
                         </label>
                     </div>
                 </td>

--- a/templates/pet_list.html
+++ b/templates/pet_list.html
@@ -36,7 +36,7 @@
                 <td id="pet-happiness-{{ pet.id }}">{{ pet.happiness }}</td>
                 <!-- ToDo: ペットの現在の成長状態の画像を追加 -->
                 <td>
-                    <div class="pet-option">
+                    <div class="pet-list-image">
                         <label>
                             {% set pet_types = ['dog', 'cat', 'bird'] %}
                             {% set growth_stage = 'adult' if pet.level >= 6 else 'young' if pet.level >= 3 else 'baby' %}

--- a/templates/pet_list.html
+++ b/templates/pet_list.html
@@ -33,7 +33,7 @@
                 <!-- ToDo: 現在のレベルを追加 -->
                 <td>{{ pet.level }}</td>
                 <!-- ToDo: 現在の幸福度を追加 -->
-                <td>{{ pet.happiness }}</td>
+                <td id="pet-happiness-{{ pet.id }}">{{ pet.happiness }}</td>
                 <!-- ToDo: ペットの現在の成長状態の画像を追加 -->
                 <td>
                     <div class="pet-option">
@@ -52,5 +52,23 @@
             {% endfor %}
         </tbody>
     </table>
+    <script>
+        async function fetchAllStates() {
+            const response = await fetch("/states");
+            const petStates = await response.json();
+    
+            // 取得したペットデータを更新
+            petStates.forEach(pet => {
+                const happinessElem = document.getElementById(`pet-happiness-${pet.id}`);
+                
+                if (happinessElem) {
+                    happinessElem.textContent = pet.happiness;
+                }
+            });
+        }
+    
+        // 1秒ごとに全てのペット情報を更新
+        setInterval(fetchAllStates, 1000);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
一覧の幸福度をページのリロードなしで更新可能に
一覧のペット画像に成長度を反映し、育成画面へのリンクを適応
cssの微調整
